### PR TITLE
update booster parent and Swarm to latest releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.openshift</groupId>
     <artifactId>booster-parent</artifactId>
-    <version>5</version>
+    <version>8</version>
   </parent>
 
   <groupId>io.openshift.boosters</groupId>
@@ -33,7 +33,7 @@
   <description>WildFly Swarm - Config Map</description>
 
   <properties>
-    <version.wildfly.swarm>2017.7.0</version.wildfly.swarm>
+    <version.wildfly.swarm>2017.8.1</version.wildfly.swarm>
     <version.resteasy>3.0.19.Final</version.resteasy>
 
     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -143,9 +143,6 @@
                 </excludes>
               </generator>
               <enricher>
-                <includes>
-                  <include>wildfly-swarm-health-check</include>
-                </includes>
                 <config>
                   <wildfly-swarm-health-check>
                     <path>/</path>

--- a/src/test/java/io/openshift/boosters/OpenshiftIT.java
+++ b/src/test/java/io/openshift/boosters/OpenshiftIT.java
@@ -182,7 +182,13 @@ public class OpenshiftIT {
                     .withLabel("deploymentconfig", name)
                     .list()
                     .getItems();
-            return pods.size() == replicas && pods.stream().allMatch(Readiness::isPodReady);
+            try {
+                return pods.size() == replicas && pods.stream().allMatch(Readiness::isPodReady);
+            } catch (IllegalStateException e) {
+                // the 'Ready' condition can be missing sometimes, in which case Readiness.isPodReady throws an exception
+                // here, we'll swallow that exception in hope that the 'Ready' condition will appear later
+                return false;
+            }
         });
     }
 }


### PR DESCRIPTION
This commit also removes an explicit `<include>`
of the `wildfly-swarm-health-check` enricher.
This is because:

- Including it is no longer necessary, latest booster
  parent prescribes Fabric8 Maven plugin 3.5.22 which
  applies this enricher automatically by default.
- An explicit include also changes order of enricher
  application.

Finally, this commit improves test stability.