### PR TITLE
chore(osio): added workaround to install config map by pipeline

### DIFF
--- a/.openshiftio/Jenkinsfile.setup.snippet
+++ b/.openshiftio/Jenkinsfile.setup.snippet
@@ -1,0 +1,7 @@
+clientsNode {
+   container(name: 'clients') {
+      checkout scm
+      sh "if ! oc get -n ${envStage} configmap app-config -o yaml | grep app-config.yml; then oc create -n ${envStage} configmap app-config --from-file=app-config.yml; fi"
+      sh "if ! oc get -n ${envProd} configmap app-config -o yaml | grep app-config.yml; then oc create -n ${envProd} configmap app-config --from-file=app-config.yml; fi"
+   }
+}


### PR DESCRIPTION
This snippet will get "injected" into the osio pipeline jenkins file to install the configmap before the app gets launched

part of fabric8-launcher/launcher-planning#119